### PR TITLE
Bugs 125 and 132: Problems on the ProfileActivity

### DIFF
--- a/src/com/andrewshu/android/reddit/ProfileActivity.java
+++ b/src/com/andrewshu/android/reddit/ProfileActivity.java
@@ -1005,7 +1005,7 @@ public final class ProfileActivity extends ListActivity
     		}
     		break;
     	case R.id.refresh_menu_id:
-			new DownloadProfileTask(mSettings.username).execute(Constants.DEFAULT_COMMENT_DOWNLOAD_LIMIT);
+			new DownloadProfileTask(mUsername).execute(Constants.DEFAULT_COMMENT_DOWNLOAD_LIMIT);
 			break;
     	}
     	

--- a/src/com/andrewshu/android/reddit/ProfileActivity.java
+++ b/src/com/andrewshu/android/reddit/ProfileActivity.java
@@ -395,7 +395,6 @@ public final class ProfileActivity extends ListActivity
 			startActivity(i);
 			return true;
     	case Constants.DIALOG_THREAD_CLICK:
-			dismissDialog(Constants.DIALOG_THREAD_CLICK);
 			// Launch an Intent for CommentsListActivity
 			CacheInfo.invalidateCachedThread(getApplicationContext());
 			i = new Intent(getApplicationContext(), CommentsListActivity.class);


### PR DESCRIPTION
Included are two commits, one for fixing the requested profile on a refresh (now for the currently viewed user, rather than the logged in username) as well as one for viewing a thread. (was hiding a dialog that was never shown?)

I'm new to git/github, so let me know if I'm doing something incorrectly, and I'll fix it as necessary.
