### PR TITLE
Added feature in issue 116

### DIFF
--- a/src/com/andrewshu/android/reddit/common/Constants.java
+++ b/src/com/andrewshu/android/reddit/common/Constants.java
@@ -74,8 +74,8 @@ public class Constants {
     public static final int SERVICE_ENVELOPE = 0;
     
     // --- Intent extras ---
-    // Tell PickSubredditActivity to hide the fronptage string
-    public static final String EXTRA_HIDE_FRONTPAGE_STRING = "hideFrontpage";
+    // Tell PickSubredditActivity to hide the fake subreddits string
+    public static final String EXTRA_HIDE_FAKE_SUBREDDITS_STRING = "hideFakeSubreddits";
     public static final String EXTRA_ID = "id";
     // Tell CommentsListActivity to jump to a comment context (a URL. pattern match)
     public static final String EXTRA_COMMENT_CONTEXT = "jumpToComment";
@@ -144,6 +144,7 @@ public class Constants {
     public static final String NO_STRING = "no";
     
     public static final String FRONTPAGE_STRING = "reddit front page";
+    
     public static final String HAVE_MAIL_TICKER = "reddit mail";
     public static final String HAVE_MAIL_TITLE = "reddit is fun";
     public static final String HAVE_MAIL_TEXT = "You have reddit mail.";

--- a/src/com/andrewshu/android/reddit/reddits/PickSubredditActivity.java
+++ b/src/com/andrewshu/android/reddit/reddits/PickSubredditActivity.java
@@ -85,7 +85,7 @@ public final class PickSubredditActivity extends ListActivity {
     private AsyncTask<?, ?, ?> mCurrentTask = null;
     private final Object mCurrentTaskLock = new Object();
 	
-    public static final String[] SUBREDDITS_MINUS_FRONTPAGE = {
+    public static final String[] DEFAULT_SUBREDDITS = {
     	"reddit.com",
     	"pics",
     	"politics",
@@ -112,6 +112,12 @@ public final class PickSubredditActivity extends ListActivity {
     	"android"
     };
     
+    // A list of special subreddits that can be viewed, but cannot be used for submissions. They inherit from the FakeSubreddit class
+    // in the redditdev source, so we use the same naming here. Note: Should we add r/Random and r/Friends?
+    public static final String[] FAKE_SUBREDDITS = {
+    	Constants.FRONTPAGE_STRING,
+    	"all"    	
+	};
     
 
 
@@ -137,7 +143,7 @@ public final class PickSubredditActivity extends ListActivity {
         	new DownloadRedditsTask().execute();
         }
         else {
-	        addFrontpageUnlessSuppressed();
+	        addFakeSubredditsUnlessSuppressed();
 	        resetUI(new PickSubredditAdapter(this, mSubredditsList));
         }
     }
@@ -329,25 +335,32 @@ public final class PickSubredditActivity extends ListActivity {
     		if (reddits == null || reddits.size() == 0) {
     			// Need to make a copy because Arrays.asList returns List backed by original array
     	        mSubredditsList = new ArrayList<String>();
-    	        mSubredditsList.addAll(Arrays.asList(SUBREDDITS_MINUS_FRONTPAGE));
+    	        mSubredditsList.addAll(Arrays.asList(DEFAULT_SUBREDDITS));
     		} else {
     			mSubredditsList = reddits;
     		}
-    		addFrontpageUnlessSuppressed();
+    		addFakeSubredditsUnlessSuppressed();
 	        resetUI(new PickSubredditAdapter(PickSubredditActivity.this, mSubredditsList));
     	}
     }
     
-    private void addFrontpageUnlessSuppressed() {
-	    // Insert front page into subreddits list, unless suppressed by Intent extras
+    private void addFakeSubredditsUnlessSuppressed() {
+	    // Insert special reddits (front page, all) into subreddits list, unless suppressed by Intent extras
 		Bundle extras = getIntent().getExtras();
+		boolean addFakeSubreddits = false;
 	    if (extras != null) {
-        	boolean shouldHideFrontpage = extras.getBoolean(Constants.EXTRA_HIDE_FRONTPAGE_STRING, false);
-        	if (!shouldHideFrontpage)
-        		mSubredditsList.add(0, Constants.FRONTPAGE_STRING);
-        } else {
-        	mSubredditsList.add(0, Constants.FRONTPAGE_STRING);
+        	boolean shouldHideFakeSubreddits = extras.getBoolean(Constants.EXTRA_HIDE_FAKE_SUBREDDITS_STRING, false);
+        	if (!shouldHideFakeSubreddits)
+        	{
+        		addFakeSubreddits = true;
+        	}
+        } else {    		
+        	addFakeSubreddits = true;    			    		
         }
+	    if (addFakeSubreddits)
+	    {
+	    	mSubredditsList.addAll(0, Arrays.asList(FAKE_SUBREDDITS));    		
+	    }
     }
 
     private final class PickSubredditAdapter extends ArrayAdapter<String> {

--- a/src/com/andrewshu/android/reddit/submit/SubmitLinkActivity.java
+++ b/src/com/andrewshu/android/reddit/submit/SubmitLinkActivity.java
@@ -644,7 +644,7 @@ public class SubmitLinkActivity extends TabActivity {
     	switch (item.getItemId()) {
     	case R.id.pick_subreddit_menu_id:
     		Intent pickSubredditIntent = new Intent(getApplicationContext(), PickSubredditActivity.class);
-    		pickSubredditIntent.putExtra(Constants.EXTRA_HIDE_FRONTPAGE_STRING, true);
+    		pickSubredditIntent.putExtra(Constants.EXTRA_HIDE_FAKE_SUBREDDITS_STRING, true);
     		startActivityForResult(pickSubredditIntent, Constants.ACTIVITY_PICK_SUBREDDIT);
     		break;
     	case R.id.update_captcha_menu_id:


### PR DESCRIPTION
Added r/all to the list of subreddits presented in the subreddit picker, as requested here:

https://github.com/talklittle/reddit-is-fun/issues/116

In addition, I added support for the other "Fake" subreddits such as r/random and r/friends, they could be added to the FAKE_SUBREDDITS array. r/all is a much needed feature, because if you want to see the logged out reddit frontpage, you had to manually type in all each time. Users without specific subreddit subscriptions might not understand this change, but it was quite obnoxious for some users.

note: I called them "fake subreddits" because that is what they are named in the reddit codebase.
