### PR TITLE
Don't show mobile versions of web sites zoomed out under ICS.

### DIFF
--- a/src/com/andrewshu/android/reddit/browser/BrowserActivity.java
+++ b/src/com/andrewshu/android/reddit/browser/BrowserActivity.java
@@ -55,6 +55,7 @@ public class BrowserActivity extends Activity {
 		settings.setJavaScriptEnabled(true);
 		settings.setUseWideViewPort(true);
 		settings.setDomStorageEnabled(true);
+		settings.setLoadWithOverviewMode(true);
 		
     	// HACK: set background color directly for android 2.0
         if (Util.isLightTheme(mSettings.getTheme()))
@@ -62,7 +63,6 @@ public class BrowserActivity extends Activity {
 
 		// use transparent background while loading
 		webview.setBackgroundColor(0);
-		webview.setInitialScale(50);
 		webview.setWebViewClient(new WebViewClient() {
 		    @Override
 		    public boolean shouldOverrideUrlLoading(WebView view, String url) {


### PR DESCRIPTION
To reproduce, just follow the link of a TIL post to wikipedia, thus loading the mobile version of wikipedia.

Under Gingerbread, mobile versions of web sites were zoomed in to fit the screen.  Under ICS (tested on a Galaxy Nexus, a Desire, and in the emulator), they're completely zoomed out, leaving the text unreadable.
