### PR TITLE
Added a setting to disable saving browsing history

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -149,6 +149,8 @@
 	
 	<string name="pref_confirm_quit">Quit confirmation</string>
  	
+	<string name="pref_save_history">Save browser history</string>
+ 	
 	<!-- Settings label -->
 	<string name="pref_theme">Theme</string>
 	<!-- Title of dialog for setting the text size -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -149,7 +149,7 @@
 	
 	<string name="pref_confirm_quit">Quit confirmation</string>
  	
-	<string name="pref_save_history">Save browser history</string>
+	<string name="pref_save_history">Save browsing history</string>
  	
 	<!-- Settings label -->
 	<string name="pref_theme">Theme</string>

--- a/res/xml/reddit_preferences.xml
+++ b/res/xml/reddit_preferences.xml
@@ -38,6 +38,10 @@
 			android:key="confirm_quit"
 			android:title="@string/pref_confirm_quit" />
 			
+		<CheckBoxPreference
+			android:key="save_history"
+			android:title="@string/pref_save_history" />
+			
 	</PreferenceCategory>
 	
 	<PreferenceCategory android:title="@string/pref_appearance_category">

--- a/src/com/andrewshu/android/reddit/browser/BrowserActivity.java
+++ b/src/com/andrewshu/android/reddit/browser/BrowserActivity.java
@@ -228,7 +228,7 @@ public class BrowserActivity extends Activity {
         case R.id.open_browser_menu_id:
     		if (mUri == null)
     			break;
-    		Common.launchBrowser(this, mUri.toString(), null, false, true, true);
+    		Common.launchBrowser(this, mUri.toString(), null, false, true, true, false);
     		break;
         
         case R.id.close_browser_menu_id:

--- a/src/com/andrewshu/android/reddit/comments/CommentsListActivity.java
+++ b/src/com/andrewshu/android/reddit/comments/CommentsListActivity.java
@@ -1310,7 +1310,7 @@ public class CommentsListActivity extends ListActivity
     	case R.id.open_browser_menu_id:
     		String url = new StringBuilder(Constants.REDDIT_BASE_URL + "/r/")
 				.append(mSubreddit).append("/comments/").append(mThreadId).toString();
-    		Common.launchBrowser(this, url, url, false, true, true);
+    		Common.launchBrowser(this, url, url, false, true, true, false);
     		break;
     	case R.id.op_delete_menu_id:
     		mReplyTargetName = getOpThingInfo().getName();
@@ -1809,7 +1809,8 @@ public class CommentsListActivity extends ListActivity
 	    					setLinkClicked(getOpThingInfo());
 	    					Common.launchBrowser(CommentsListActivity.this, url,
 	    							Util.createThreadUri(getOpThingInfo()).toString(),
-	    							false, false, mSettings.isUseExternalBrowser());
+	    							false, false, mSettings.isUseExternalBrowser(),
+	    							mSettings.isSaveHistory());
 	    				}
 	    			});
 	    			linkButton.setEnabled(true);
@@ -1952,7 +1953,8 @@ public class CommentsListActivity extends ListActivity
     	                    if (which >= 0) {
     	                        Common.launchBrowser(CommentsListActivity.this, urls.get(which),
     	                        		Util.createThreadUri(getOpThingInfo()).toString(),
-    	                        		false, false, mSettings.isUseExternalBrowser());
+    	                        		false, false, mSettings.isUseExternalBrowser(),
+    	                        		mSettings.isSaveHistory());
     	                    }
     	                }
     	            };
@@ -2077,7 +2079,8 @@ public class CommentsListActivity extends ListActivity
 							Util.createThreadUri(threadThingInfo).toString(),
 							false,
 							false,
-							mSettings.isUseExternalBrowser()
+							mSettings.isUseExternalBrowser(),
+							mSettings.isSaveHistory()
 					);
 				}
 			};

--- a/src/com/andrewshu/android/reddit/common/Common.java
+++ b/src/com/andrewshu/android/reddit/common/Common.java
@@ -410,10 +410,13 @@ public class Common {
      * @param useExternalBrowser
      */
     public static void launchBrowser(Context context, String url, String threadUrl,
-    		boolean requireNewTask, boolean bypassParser, boolean useExternalBrowser) {
+			boolean requireNewTask, boolean bypassParser, boolean useExternalBrowser,
+			boolean saveHistory) {
     	
     	try {
-    		Browser.updateVisitedHistory(context.getContentResolver(), url, true);
+			if (saveHistory) {
+				Browser.updateVisitedHistory(context.getContentResolver(), url, true);
+			}
     	} catch (Exception ex) {
     		if (Constants.LOGGING) Log.i(TAG, "Browser.updateVisitedHistory error", ex);
     	}

--- a/src/com/andrewshu/android/reddit/common/Constants.java
+++ b/src/com/andrewshu/android/reddit/common/Constants.java
@@ -281,6 +281,7 @@ public class Constants {
     public static final String PREF_HOMEPAGE = "homepage";
     public static final String PREF_USE_EXTERNAL_BROWSER = "use_external_browser";
     public static final String PREF_CONFIRM_QUIT = "confirm_quit";
+    public static final String PREF_SAVE_HISTORY = "save_history";
     public static final String PREF_ALWAYS_SHOW_NEXT_PREVIOUS = "always_show_next_previous";
     public static final String PREF_COMMENTS_SORT_BY_URL = "sort_by_url";
     public static final String PREF_THEME = "theme";

--- a/src/com/andrewshu/android/reddit/settings/RedditSettings.java
+++ b/src/com/andrewshu/android/reddit/settings/RedditSettings.java
@@ -53,6 +53,7 @@ public class RedditSettings {
 	private boolean useExternalBrowser = false;
 	private boolean showCommentGuideLines = true;
 	private boolean confirmQuit = true;
+	private boolean saveHistory = true;
 	private boolean alwaysShowNextPrevious = true;
 	
 	private int threadDownloadLimit = Constants.DEFAULT_THREAD_DOWNLOAD_LIMIT;
@@ -132,9 +133,12 @@ public class RedditSettings {
     	
     	// Use external browser instead of BrowserActivity
     	editor.putBoolean(Constants.PREF_USE_EXTERNAL_BROWSER, this.useExternalBrowser);
-    	
+
     	// Show confirmation dialog when backing out of root Activity
     	editor.putBoolean(Constants.PREF_CONFIRM_QUIT, this.confirmQuit);
+
+    	// Save reddit history to Browser history
+    	editor.putBoolean(Constants.PREF_SAVE_HISTORY, this.saveHistory);
     	
     	// Whether to always show the next/previous buttons, or only at bottom of list
     	editor.putBoolean(Constants.PREF_ALWAYS_SHOW_NEXT_PREVIOUS, this.alwaysShowNextPrevious);
@@ -199,9 +203,12 @@ public class RedditSettings {
         
     	// Use external browser instead of BrowserActivity
         this.setUseExternalBrowser(sessionPrefs.getBoolean(Constants.PREF_USE_EXTERNAL_BROWSER, false));
-        
+
     	// Show confirmation dialog when backing out of root Activity
         this.setConfirmQuit(sessionPrefs.getBoolean(Constants.PREF_CONFIRM_QUIT, true));
+
+    	// Show confirmation dialog when backing out of root Activity
+        this.setSaveHistory(sessionPrefs.getBoolean(Constants.PREF_SAVE_HISTORY, true));
         
     	// Whether to always show the next/previous buttons, or only at bottom of list
         this.setAlwaysShowNextPrevious(sessionPrefs.getBoolean(Constants.PREF_ALWAYS_SHOW_NEXT_PREVIOUS, true));
@@ -287,8 +294,16 @@ public class RedditSettings {
 		return confirmQuit;
 	}
 
+	public boolean isSaveHistory() {
+		return saveHistory;
+	}
+
 	public void setConfirmQuit(boolean confirmQuit) {
 		this.confirmQuit = confirmQuit;
+	}
+
+	public void setSaveHistory(boolean saveHistory) {
+		this.saveHistory = saveHistory;
 	}
 
 	public boolean isAlwaysShowNextPrevious() {

--- a/src/com/andrewshu/android/reddit/threads/ThreadsListActivity.java
+++ b/src/com/andrewshu/android/reddit/threads/ThreadsListActivity.java
@@ -1001,7 +1001,7 @@ public final class ThreadsListActivity extends ListActivity {
 			
 		case Constants.OPEN_IN_BROWSER_CONTEXT_ITEM:
 			setLinkClicked(_item);
-			Common.launchBrowser(this, _item.getUrl(), Util.createThreadUri(_item).toString(), false, true, true);
+			Common.launchBrowser(this, _item.getUrl(), Util.createThreadUri(_item).toString(), false, true, true, false);
 			return true;
 			
 		case Constants.SAVE_CONTEXT_ITEM:
@@ -1140,7 +1140,7 @@ public final class ThreadsListActivity extends ListActivity {
     			url = Constants.REDDIT_BASE_URL;
     		else
         		url = new StringBuilder(Constants.REDDIT_BASE_URL + "/r/").append(mSubreddit).toString();
-    		Common.launchBrowser(this, url, null, false, true, true);
+    		Common.launchBrowser(this, url, null, false, true, true, false);
     		break;
         case R.id.light_dark_menu_id:
     		mSettings.setTheme(Util.getInvertedTheme(mSettings.getTheme()));
@@ -1377,7 +1377,8 @@ public final class ThreadsListActivity extends ListActivity {
 							Util.createThreadUri(threadThingInfo).toString(),
 							false,
 							false,
-							mSettings.isUseExternalBrowser()
+							mSettings.isUseExternalBrowser(),
+							mSettings.isSaveHistory()
 					);
 				}
 			};
@@ -1403,7 +1404,7 @@ public final class ThreadsListActivity extends ListActivity {
 					setLinkClicked(thingInfo);
 					Common.launchBrowser(ThreadsListActivity.this, thingInfo.getUrl(),
 							Util.createThreadUri(thingInfo).toString(),
-							false, false, useExternalBrowser);
+							false, false, useExternalBrowser, false);
 				}
 			};
     	}

--- a/src/com/andrewshu/android/reddit/threads/ThreadsListActivity.java
+++ b/src/com/andrewshu/android/reddit/threads/ThreadsListActivity.java
@@ -1001,7 +1001,7 @@ public final class ThreadsListActivity extends ListActivity {
 			
 		case Constants.OPEN_IN_BROWSER_CONTEXT_ITEM:
 			setLinkClicked(_item);
-			Common.launchBrowser(this, _item.getUrl(), Util.createThreadUri(_item).toString(), false, true, true, false);
+			Common.launchBrowser(this, _item.getUrl(), Util.createThreadUri(_item).toString(), false, true, true, mSettings.isSaveHistory());
 			return true;
 			
 		case Constants.SAVE_CONTEXT_ITEM:
@@ -1140,7 +1140,7 @@ public final class ThreadsListActivity extends ListActivity {
     			url = Constants.REDDIT_BASE_URL;
     		else
         		url = new StringBuilder(Constants.REDDIT_BASE_URL + "/r/").append(mSubreddit).toString();
-    		Common.launchBrowser(this, url, null, false, true, true, false);
+    		Common.launchBrowser(this, url, null, false, true, true, mSettings.isSaveHistory());
     		break;
         case R.id.light_dark_menu_id:
     		mSettings.setTheme(Util.getInvertedTheme(mSettings.getTheme()));
@@ -1404,7 +1404,7 @@ public final class ThreadsListActivity extends ListActivity {
 					setLinkClicked(thingInfo);
 					Common.launchBrowser(ThreadsListActivity.this, thingInfo.getUrl(),
 							Util.createThreadUri(thingInfo).toString(),
-							false, false, useExternalBrowser, false);
+							false, false, useExternalBrowser, mSettings.isSaveHistory());
 				}
 			};
     	}

--- a/src/com/andrewshu/android/reddit/user/ProfileActivity.java
+++ b/src/com/andrewshu/android/reddit/user/ProfileActivity.java
@@ -1186,7 +1186,8 @@ public final class ProfileActivity extends ListActivity
 							Util.createThreadUri(threadThingInfo).toString(),
 							false,
 							false,
-							mSettings.isUseExternalBrowser()
+							mSettings.isUseExternalBrowser(),
+							mSettings.isSaveHistory()
 					);
 				}
 			};
@@ -1214,7 +1215,7 @@ public final class ProfileActivity extends ListActivity
 					// Launch Intent to goto the URL
 					Common.launchBrowser(ProfileActivity.this, info.getUrl(),
 							Util.createThreadUri(info).toString(),
-							false, false, fUseExternalBrowser);
+							false, false, fUseExternalBrowser, false);
 				}
 			};
 		}

--- a/src/com/andrewshu/android/reddit/user/ProfileActivity.java
+++ b/src/com/andrewshu/android/reddit/user/ProfileActivity.java
@@ -1215,7 +1215,7 @@ public final class ProfileActivity extends ListActivity
 					// Launch Intent to goto the URL
 					Common.launchBrowser(ProfileActivity.this, info.getUrl(),
 							Util.createThreadUri(info).toString(),
-							false, false, fUseExternalBrowser, false);
+							false, false, fUseExternalBrowser, mSettings.isSaveHistory());
 				}
 			};
 		}


### PR DESCRIPTION
First off, I love this app.  Secondly, I appreciate the reasoning behind the recent changes that some people are complaining about, and considering that this is not only a free, but also an open source app, I don't think they should be complaining.  But with that being said, I think saving Reddit Is Fun browsing history to the default Browser's history without a way to turn that off is not ideal.

This pull request contains changes that add an additional setting under the General Settings section that allows you to disable saving browsing history.  When unchecked this setting will revert the app back to its previous behavior of not saving Reddit Is Fun browsing history to the default Android web browser's history.
