### PR TITLE
replace AsyncTask with AsyncTaskLoader

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -30,7 +30,7 @@
 	<uses-permission android:name="com.android.browser.permission.READ_HISTORY_BOOKMARKS" />
     <uses-permission android:name="com.android.browser.permission.WRITE_HISTORY_BOOKMARKS" />
 	
-    <uses-sdk android:minSdkVersion="4" android:targetSdkVersion="11" />
+    <uses-sdk android:minSdkVersion="11" android:targetSdkVersion="11" />
 
     <supports-screens />
     


### PR DESCRIPTION
Hello, I'm doing research on Android async programming. Some articles (for example [this article](http://bon-app-etit.blogspot.com/2013/04/the-dark-side-of-asynctask.html)) mention that AsyncTask leads to memory leak and losing task result when there's a configuration change (such as orientation change). Android docs recommend [AsyncTaskLoader](http://developer.android.com/reference/android/content/AsyncTaskLoader.html) (require API level 11), which avoid the problems in AsyncTask.

I try to replace one AsyncTask with AsyncTaskLoader in `reddit-is-fun` in this pr (you don't have to merge). Do you think AsyncTaskLoader will work better for `reddit-is-fun`? Do you want to replace all AsyncTask to AsyncTaskLoader?
